### PR TITLE
ブロック一覧にある編集ボタンはタイトルの横ではなく、1つの列としてガタガタしないようにする

### DIFF
--- a/View/FaqBlocks/index.ctp
+++ b/View/FaqBlocks/index.ctp
@@ -27,7 +27,7 @@
 							); ?>
 						<?php echo $this->BlockIndex->tableHeader(
 								'Block.name', __d('faqs', 'FAQ Name'),
-								array('sort' => true)
+								array('sort' => true, 'editUrl' => true)
 							); ?>
 						<?php echo $this->BlockIndex->tableHeader(
 								'TrackableCreator.handlename', __d('net_commons', 'Created user'),


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/261
